### PR TITLE
修复历史账单周期用量usage，水表数字段异常问题

### DIFF
--- a/custom_components/bj_water/sensor.py
+++ b/custom_components/bj_water/sensor.py
@@ -244,13 +244,27 @@ class BJWaterHistoryUsageSensor(BJWaterBaseSensor):
     def unit_of_measurement(self):
         return "m³"
 
+    # @property
+    # def extra_state_attributes(self):
+    #     attrs = {}
+    #     for k, v in self.sensor_attrs.items():
+    #         attrs[HISTORY_USAGE_SENSORS[k]["name"]] = v
+    #     LOGGER.info("BJWaterHistoryUsageSensor: " + str(attrs))
+    #     return attrs
+    
     @property
     def extra_state_attributes(self):
         attrs = {}
         for k, v in self.sensor_attrs.items():
-            attrs[HISTORY_USAGE_SENSORS[k]["name"]] = v
-        LOGGER.info("BJWaterHistoryUsageSensor: " + str(attrs))
+            if k == "usage":
+                attrs[HISTORY_USAGE_SENSORS[k]["name"]] = v
+            elif k == "value":
+                if isinstance(v, list) and len(v) > 0:
+                    value_list = v[0]
+                    if isinstance(value_list, list) and len(value_list) > 0:
+                        attrs[HISTORY_USAGE_SENSORS[k]["name"]] = value_list[0]
         return attrs
+
 
     @property
     def device_class(self) -> str | None:


### PR DESCRIPTION
借助chatgpt修复了，修复后效果

```
type: custom:flex-table-card
title: 用水情况
entities:
  include: sensor.100000000_*_usage
  exclude: sensor.100000000_total_usage
columns:
  - name: 月份
    data: name
  - name: 用水量
    data: 总用水量
    suffix: m³
  - name: 水表数
    data: 水表数
    suffix: m³
```
<img width="498" alt="image" src="https://github.com/WeiYang1982/bj_water/assets/23189213/23597475-332c-486f-99f9-83742f759398">